### PR TITLE
lifted com.typesafe's config library to 1.3.0 and Java8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: scala
 scala:
   - 2.11.7
 jdk:
-  - openjdk-8
   - oraclejdk8
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: scala
 scala:
   - 2.11.7
 jdk:
-  - openjdk7
-  - oraclejdk7
+  - openjdk8
+  - oraclejdk8
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala:
   - 2.11.7
 jdk:
-  - openjdk8
+  - openjdk-8
   - oraclejdk8
 
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,7 @@ scalacOptions <++= scalaVersion map { sv =>
     "-feature",
     "-language:postfixOps",
     "-language:implicitConversions",
-    "-language:higherKinds",
-    "-target:jvm-1.8"
+    "-language:higherKinds"
   )
   else 
     List("-target:jvm-1.8")

--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,11 @@ scalacOptions <++= scalaVersion map { sv =>
     "-feature",
     "-language:postfixOps",
     "-language:implicitConversions",
-    "-language:higherKinds"
+    "-language:higherKinds",
+    "-target:jvm-1.8"
   )
-  else Nil
+  else 
+    List("-target:jvm-1.8")
 }
 
 javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies <++= scalaVersion { sv =>
     "org.specs2"     %% "specs2"         % "2.3.11"   % "test",
     "org.scalacheck" %% "scalacheck"     % "1.11.3"   % "test",
     "com.chuusai"    %% "shapeless"      % "2.0.0"    % "test",
-    "com.typesafe"   %  "config"         % "1.2.1",
+    "com.typesafe"   %  "config"         % "1.3.0",
     "org.scala-lang" %  "scala-reflect"  % sv         % "provided")
 }
 

--- a/travis-jvmopts
+++ b/travis-jvmopts
@@ -1,4 +1,3 @@
 -Xss1M
 -Xms512M
 -Xmx512M
--XX:MaxPermSize=128M


### PR DESCRIPTION
The wrapped config library has been updated to a new (compatible) version. Tests still run.