### PR TITLE
add cross scala versions to support 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,24 +5,24 @@ description := "A Scala-friendly wrapper companion for Typesafe config"
 
 startYear := Some(2013)
 
-
 /* scala versions and options */
 scalaVersion := "2.11.8"
 
+crossScalaVersions := Seq(scalaVersion.value, "2.10.6")
+
 // These options will be used for *all* versions.
 scalacOptions ++= Seq(
+  "-feature",
   "-deprecation",
   "-unchecked",
-  "-encoding", "UTF-8"
-)
-
-scalacOptions ++= Seq(
+  "-encoding", "UTF-8",
   "-Yclosure-elim",
-  "-Yinline"
-)
-
-scalacOptions ++= Seq(
-  "-target:jvm-1.8"
+  "-Yinline",
+  "-target:jvm-1." + {
+    CrossVersion.partialVersion(scalaVersion.value).collect {
+      case (2, minor) if minor <= 10 => "7"
+    }.getOrElse("8")
+  }
 )
 
 javacOptions ++= Seq(
@@ -36,7 +36,10 @@ libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck"        % "1.13.0" % "test",
   "com.chuusai"    %% "shapeless"         % "2.3.0"  % "test",
   "com.typesafe"   %  "config"            % "1.3.0",
-  "org.scala-lang" %  "scala-reflect"     % scalaVersion.value % "provided"
+  "org.scala-lang" %  "scala-reflect"     % scalaVersion.value % "provided",
+  "org.scala-lang" % "scala-compiler"     % scalaVersion.value % "provided",
+  "org.typelevel"  %% "macro-compat"      % "1.1.1",
+  compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 )
 
 /* you may need these repos */

--- a/src/main/scala/net/ceedubs/ficus/Ficus.scala
+++ b/src/main/scala/net/ceedubs/ficus/Ficus.scala
@@ -2,6 +2,7 @@ package net.ceedubs.ficus
 
 import com.typesafe.config.Config
 import net.ceedubs.ficus.readers._
+import scala.language.implicitConversions
 
 trait FicusInstances extends AnyValReaders with StringReader with OptionReader
     with CollectionReaders with ConfigReader with DurationReaders

--- a/src/main/scala/net/ceedubs/ficus/FicusConfig.scala
+++ b/src/main/scala/net/ceedubs/ficus/FicusConfig.scala
@@ -2,6 +2,7 @@ package net.ceedubs.ficus
 
 import com.typesafe.config.Config
 import net.ceedubs.ficus.readers.{AllValueReaderInstances, ValueReader}
+import scala.language.implicitConversions
 
 trait FicusConfig {
   def config: Config

--- a/src/main/scala/net/ceedubs/ficus/readers/BigNumberReaders.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/BigNumberReaders.scala
@@ -1,5 +1,7 @@
 package net.ceedubs.ficus.readers
 
+import java.math.MathContext
+
 import com.typesafe.config.{ConfigException, Config}
 
 trait BigNumberReaders {

--- a/src/main/scala/net/ceedubs/ficus/readers/CollectionReaders.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/CollectionReaders.scala
@@ -3,7 +3,8 @@ package net.ceedubs.ficus.readers
 import com.typesafe.config.{ConfigUtil, Config}
 import collection.JavaConverters._
 import collection.generic.CanBuildFrom
-import scala.reflect.ClassTag
+import scala.language.postfixOps
+import scala.language.higherKinds
 
 trait CollectionReaders {
 

--- a/src/main/scala/net/ceedubs/ficus/util/ReflectionUtils.scala
+++ b/src/main/scala/net/ceedubs/ficus/util/ReflectionUtils.scala
@@ -1,10 +1,15 @@
 package net.ceedubs.ficus.util
 
-import scala.reflect.macros.blackbox.Context
+import macrocompat.bundle
+import scala.reflect.macros.blackbox
 
-object ReflectionUtils {
-  def instantiationMethod[T : c.WeakTypeTag](c: Context, fail: String => Nothing): c.universe.MethodSymbol = {
-    import c.universe._
+@bundle
+trait ReflectionUtils {
+  val c: blackbox.Context
+
+  import c.universe._
+
+  def instantiationMethod[T : c.WeakTypeTag](fail: String => Nothing): c.universe.MethodSymbol = {
 
     val returnType = c.weakTypeOf[T]
 

--- a/src/test/scala/net/ceedubs/ficus/ConfigSerializer.scala
+++ b/src/test/scala/net/ceedubs/ficus/ConfigSerializer.scala
@@ -1,6 +1,7 @@
 package net.ceedubs.ficus
 
 import com.typesafe.config.ConfigUtil
+import scala.language.implicitConversions
 
 trait ConfigSerializer[A] {
   def serialize(a: A): String

--- a/src/test/scala/net/ceedubs/ficus/readers/BigNumberReadersSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/readers/BigNumberReadersSpec.scala
@@ -2,7 +2,6 @@ package net.ceedubs.ficus.readers
 
 import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Spec
-import org.specs2.specification.core.Fragments
 
 class BigNumberReadersSpec extends Spec with BigNumberReaders { def is = s2"""
   The BigDecimal value reader should
@@ -37,7 +36,7 @@ class BigNumberReadersSpec extends Spec with BigNumberReaders { def is = s2"""
     bigDecimalReader.read(cfg,"myValue") must beEqualTo(BigDecimal(i))
   }
   
-  def readBigDecimal = prop{ b: BigDecimal => 
+  def readBigDecimal = prop{ b: BigDecimal =>
     scala.util.Try(BigDecimal(b.toString)).toOption.isDefined ==> {
       val cfg = ConfigFactory.parseString(s"myValue = $b")
       bigDecimalReader.read(cfg, "myValue") must beEqualTo(b)

--- a/src/test/scala/net/ceedubs/ficus/readers/CollectionReadersSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/readers/CollectionReadersSpec.scala
@@ -8,6 +8,7 @@ import ConfigSerializerOps._
 import org.scalacheck.util.Buildable
 import org.scalacheck.Arbitrary
 import CollectionReaderSpec._
+import scala.language.higherKinds
 
 class CollectionReadersSpec extends Spec with CollectionReaders { def is = s2"""
   The collection value readers should


### PR DESCRIPTION
* adds `crossScalaVersions` settings to enable publishing to 2.10 fixes #20
* migrates macros to use [macro-compat](https://github.com/milessabin/macro-compat)

There is an unresolved issue with involving scala 2.10's handling of high precision `BigDecimal`s. Some of the property-based tests fail when run with 2.10.6. To recreate, run `++2.10.6 test-only net.ceedubs.ficus.readers.BigNumberReadersSpec`.