### PR TITLE
Read finite duration from nanos to keep unit

### DIFF
--- a/src/main/scala/net/ceedubs/ficus/readers/DurationReaders.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/DurationReaders.scala
@@ -2,7 +2,7 @@ package net.ceedubs.ficus.readers
 
 import scala.concurrent.duration.FiniteDuration
 import com.typesafe.config.Config
-import scala.concurrent.duration.MILLISECONDS
+import scala.concurrent.duration.{Duration, NANOSECONDS}
 
 trait DurationReaders {
 
@@ -13,8 +13,8 @@ trait DurationReaders {
    */
   implicit def finiteDurationReader: ValueReader[FiniteDuration] = new ValueReader[FiniteDuration] {
     def read(config: Config, path: String): FiniteDuration = {
-      val millis = config.getDuration(path, java.util.concurrent.TimeUnit.MILLISECONDS)
-      FiniteDuration(millis, MILLISECONDS)
+      val nanos = config.getDuration(path, NANOSECONDS)
+      Duration.fromNanos(nanos)
     }
   }
 }

--- a/src/test/scala/net/ceedubs/ficus/readers/DurationReadersSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/readers/DurationReadersSpec.scala
@@ -2,6 +2,7 @@ package net.ceedubs.ficus
 package readers
 
 import com.typesafe.config.ConfigFactory
+
 import scala.concurrent.duration._
 import org.scalacheck.{Gen, Prop}
 
@@ -9,6 +10,7 @@ class DurationReadersSpec extends Spec with DurationReaders { def is = s2"""
   The finite duration reader should
     read a millisecond value $readMillis
     read a minute value $readMinutes
+    read a days value into days $readDaysUnit
   """
 
   def readMillis = prop { i: Int =>
@@ -16,9 +18,14 @@ class DurationReadersSpec extends Spec with DurationReaders { def is = s2"""
     finiteDurationReader.read(cfg, "myValue") must beEqualTo(i millis)
   }
 
-  def readMinutes = Prop.forAll(Gen.choose(1.5e-8.toInt, 1.5e8.toInt)) { i: Int =>
+  def readMinutes = Prop.forAll(Gen.choose(-1.5e8.toInt, 1.5e8.toInt)) { i: Int =>
     val cfg = ConfigFactory.parseString("myValue = \"" + i + " minutes\"")
     finiteDurationReader.read(cfg, "myValue") must beEqualTo(i minutes)
   }
 
+  def readDaysUnit = Prop.forAll(Gen.choose(-106580, 106580)) { i: Int =>
+    val str = i + " day" + (if (i == 1) "" else "s")
+    val cfg = ConfigFactory.parseString(s"""myValue = "$str" """)
+    finiteDurationReader.read(cfg, "myValue").toString must beEqualTo(str)
+  }
 }


### PR DESCRIPTION
Previously, the `FiniteDuration` reader converted everything to milliseconds. This causes two problems:

  1. You may lose precision from nanoseconds
  2. The `toString` will be pretty much unreadable for larger time units (for example "15 days" becomes "1296000000 milliseconds")

This PR changes it to maintain the unit, and preserve nanosecond precision, by using `Duration.fromNanos` which specifically handles both those issues.

