### PR TITLE
Added reader for Java URL type.

### DIFF
--- a/src/main/scala/net/ceedubs/ficus/Ficus.scala
+++ b/src/main/scala/net/ceedubs/ficus/Ficus.scala
@@ -7,7 +7,7 @@ import scala.language.implicitConversions
 trait FicusInstances extends AnyValReaders with StringReader with SymbolReader with OptionReader
     with CollectionReaders with ConfigReader with DurationReaders
     with TryReader with ConfigValueReader with BigNumberReaders
-    with ISOZonedDateTimeReader with PeriodReader with LocalDateReader with URIReaders
+    with ISOZonedDateTimeReader with PeriodReader with LocalDateReader with URIReaders with URLReader
 
 object Ficus extends FicusInstances {
   implicit def toFicusConfig(config: Config): FicusConfig = SimpleFicusConfig(config)

--- a/src/main/scala/net/ceedubs/ficus/readers/URLReader.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/URLReader.scala
@@ -1,0 +1,21 @@
+package net.ceedubs.ficus.readers
+
+import java.net.{URL, MalformedURLException}
+
+import com.typesafe.config.{Config, ConfigException}
+
+trait URLReader {
+  implicit val javaURLReader: ValueReader[URL] = new ValueReader[URL] {
+    def read(config: Config, path: String): URL = {
+      val s = config.getString(path)
+      try {
+        new URL(s)
+      } catch {
+        case e: MalformedURLException =>
+          throw new ConfigException.WrongType(config.origin(), path, "java.net.URL", "String", e)
+      }
+    }
+  }
+}
+
+object URLReader extends URLReader

--- a/src/test/scala/net/ceedubs/ficus/readers/URLReaderSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/readers/URLReaderSpec.scala
@@ -1,0 +1,28 @@
+package net.ceedubs.ficus.readers
+
+import java.net.URL
+
+import com.typesafe.config.ConfigException.WrongType
+import com.typesafe.config.ConfigFactory
+import net.ceedubs.ficus.Spec
+import org.specs2.matcher.MatchResult
+
+class URLReaderSpec extends Spec with URLReader with TryReader {
+  def is = s2"""
+  The URL value reader should
+    read a valid URL $readValidURL
+    detect wrong type on malformed URL (with an unsupported protocol) $readMalformedURL
+  """
+
+  def readValidURL: MatchResult[URL] = {
+    val url = """https://www.google.com"""
+    val cfg = ConfigFactory.parseString(s"myValue = ${"\"" + url + "\""}")
+    javaURLReader.read(cfg, "myValue") must beEqualTo(new URL(url))
+  }
+
+  def readMalformedURL: MatchResult[Any] = {
+    val malformedUrl = """foo://bar.com"""
+    val cfg = ConfigFactory.parseString(s"myValue = ${"\"" + malformedUrl + "\""}")
+    javaURLReader.read(cfg, "myValue") must throwA[WrongType]
+  }
+}


### PR DESCRIPTION
I needed `ficus` to parse `java.net.URL` instead of `java.net.URI` (for which support was added 2 days ago with #49).

Just like it was mentioned by @mdedetrich, extensive testing is not trivial so I did just added a basic testi for malformed URL which could be easily extended on demand.