### PR TITLE
initial POC for 'as' API addition

### DIFF
--- a/src/main/scala/net/ceedubs/ficus/FicusConfig.scala
+++ b/src/main/scala/net/ceedubs/ficus/FicusConfig.scala
@@ -1,13 +1,14 @@
 package net.ceedubs.ficus
 
 import com.typesafe.config.Config
-import net.ceedubs.ficus.readers.{AllValueReaderInstances, ValueReader}
+import net.ceedubs.ficus.readers.{AllValueReaderInstances, CompositeValueReader, ValueReader}
+
 import scala.language.implicitConversions
 
 trait FicusConfig {
   def config: Config
 
-  def as[A]()(implicit reader : ValueReader[A]) : A = reader.read(config)
+  def as[A](implicit reader : CompositeValueReader[A]) : A = reader.read(config)
 
   def as[A](path: String)(implicit reader: ValueReader[A]): A = reader.read(config, path)
 

--- a/src/main/scala/net/ceedubs/ficus/FicusConfig.scala
+++ b/src/main/scala/net/ceedubs/ficus/FicusConfig.scala
@@ -7,6 +7,8 @@ import scala.language.implicitConversions
 trait FicusConfig {
   def config: Config
 
+  def as[A]()(implicit reader : ValueReader[A]) : A = reader.read(config)
+
   def as[A](path: String)(implicit reader: ValueReader[A]): A = reader.read(config, path)
 
   def getAs[A](path: String)(implicit reader: ValueReader[Option[A]]): Option[A] = reader.read(config, path)

--- a/src/main/scala/net/ceedubs/ficus/readers/BigNumberReaders.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/BigNumberReaders.scala
@@ -1,7 +1,5 @@
 package net.ceedubs.ficus.readers
 
-import java.math.MathContext
-
 import com.typesafe.config.{ConfigException, Config}
 
 trait BigNumberReaders {

--- a/src/main/scala/net/ceedubs/ficus/readers/CompositeValueReader.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/CompositeValueReader.scala
@@ -1,0 +1,26 @@
+package net.ceedubs.ficus.readers
+
+import com.typesafe.config.Config
+
+/**
+  * A CompositeValueReader is a spiritual cousin of ValueReader.  Whereas a ValueReader wants to read a single value from a single
+  * path in a Config object, a CompositeValueReader instead reads a single value using the entire Config passed in.
+  * @tparam A
+  */
+trait CompositeValueReader[A]{ self =>
+
+  /**
+    * Convert the `config` object into an `A`
+    * @param config
+    * @return
+    */
+  def read(config : Config) : A
+
+  /**
+    * Turns a CompositeValueReader[A] into a CompositeValueReader[B] by applying the provided transformation `f` on the item of type A
+    * that is read from config
+    */
+  def map[B](f: A => B): CompositeValueReader[B] = new CompositeValueReader[B] {
+    def read(config: Config): B = f(self.read(config))
+  }
+}

--- a/src/main/scala/net/ceedubs/ficus/readers/ValueReader.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/ValueReader.scala
@@ -8,8 +8,6 @@ trait ValueReader[A] { self =>
   /** Reads the value at the path `path` in the Config */
   def read(config: Config, path: String): A
 
-  def read(config : Config) : A = throw new Exception("bla") //TODO: FIX THIS EXCEPTION
-
   /**
    * Turns a ValueReader[A] into a ValueReader[B] by applying the provided transformation `f` on the item of type A
    * that is read from config

--- a/src/main/scala/net/ceedubs/ficus/readers/ValueReader.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/ValueReader.scala
@@ -8,6 +8,8 @@ trait ValueReader[A] { self =>
   /** Reads the value at the path `path` in the Config */
   def read(config: Config, path: String): A
 
+  def read(config : Config) : A = throw new Exception("bla") //TODO: FIX THIS EXCEPTION
+
   /**
    * Turns a ValueReader[A] into a ValueReader[B] by applying the provided transformation `f` on the item of type A
    * that is read from config

--- a/src/test/scala/net/ceedubs/ficus/FicusConfigSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/FicusConfigSpec.scala
@@ -13,7 +13,7 @@ class FicusConfigSpec extends Spec { def is = s2"""
     getOrElse an existing value as asked type $getOrElseFromConfig
     getOrElse a missing value with default value $getOrElseFromDefault
     getOrElse an existing value as asked type with customer reader $getOrElseFromConfigWithCustomValueReader
-    accept a CongigKey and return the appropriate type $acceptAConfigKey
+    accept a ConfigKey and return the appropriate type $acceptAConfigKey
   """
 
   def implicitlyConverted = {

--- a/src/test/scala/net/ceedubs/ficus/FicusConfigSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/FicusConfigSpec.scala
@@ -1,13 +1,20 @@
 package net.ceedubs.ficus
 
 import com.typesafe.config.{Config, ConfigFactory}
-import Ficus.{ booleanValueReader, optionValueReader, stringValueReader, toFicusConfig }
+import Ficus.{ booleanValueReader, longValueReader, optionValueReader, stringValueReader, toFicusConfig }
+import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 import net.ceedubs.ficus.readers.ValueReader
+import ConfigSerializerOps._
+
+object FicusConfigSpec{
+  case class MultipleFields(string: String, long: Long)
+}
 
 class FicusConfigSpec extends Spec { def is = s2"""
   A Ficus config should
     be implicitly converted from a Typesafe config $implicitlyConverted
     read a value with a value reader $readAValue
+    read a value with a composite value reader $readAValue
     get an existing value as a Some $getAsSome
     get a missing value as a None $getAsNone
     getOrElse an existing value as asked type $getOrElseFromConfig
@@ -15,6 +22,8 @@ class FicusConfigSpec extends Spec { def is = s2"""
     getOrElse an existing value as asked type with customer reader $getOrElseFromConfigWithCustomValueReader
     accept a ConfigKey and return the appropriate type $acceptAConfigKey
   """
+
+  import FicusConfigSpec._
 
   def implicitlyConverted = {
     val cfg = ConfigFactory.parseString("myValue = true")
@@ -24,6 +33,18 @@ class FicusConfigSpec extends Spec { def is = s2"""
   def readAValue = prop { b: Boolean =>
     val cfg = ConfigFactory.parseString(s"myValue = $b")
     cfg.as[Boolean]("myValue") must beEqualTo(b)
+  }
+
+  def multipleFields = prop { (foo: String, long: Long) =>
+    val cfg = ConfigFactory.parseString(
+      s"""
+         |{
+         |  string = ${foo.asConfigValue}
+         |  long = $long
+         |}
+      """.stripMargin)
+    val x: MultipleFields = cfg.as[MultipleFields]
+    cfg.as[MultipleFields] must_== MultipleFields(string = foo, long = long)
   }
 
   def getAsSome = prop { b: Boolean =>

--- a/src/test/scala/net/ceedubs/ficus/readers/CaseClassReadersSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/readers/CaseClassReadersSpec.scala
@@ -25,6 +25,8 @@ class CaseClassReadersSpec extends Spec { def is = s2"""
     hydrate a case class with multiple fields $multipleFields
     use another implicit value reader for a field $withOptionField
     read a nested case class $withNestedCaseClass
+    read a top-level case class $withTopLevelCaseClass
+    read a top-level case class with nested case class $withTopLevelCaseClassWithNestedCaseClass
     read a top-level value class $topLevelValueClass
     read a nested value class $nestedValueClass
     fall back to a default value $fallbackToDefault
@@ -69,6 +71,22 @@ class CaseClassReadersSpec extends Spec { def is = s2"""
         |}
       """.stripMargin)
     cfg.as[WithNestedCaseClass]("withNested") must_== WithNestedCaseClass(
+      simple = SimpleCaseClass(bool = bool))
+  }
+
+  def withTopLevelCaseClass = prop{ bool : Boolean =>
+    val cfg = ConfigFactory.parseString(s"{bool = $bool}")
+    cfg.as[SimpleCaseClass] must_== SimpleCaseClass(bool = bool)
+  }
+
+  def withTopLevelCaseClassWithNestedCaseClass = prop{bool : Boolean =>
+    val cfg = ConfigFactory.parseString(
+      s"""
+         |  simple {
+         |    bool = $bool
+         |  }
+      """.stripMargin)
+    cfg.as[WithNestedCaseClass] must_== WithNestedCaseClass(
       simple = SimpleCaseClass(bool = bool))
   }
 


### PR DESCRIPTION
I had a longer than expected plane ride the other day, and decided to take a stab at #8 .

This PR is a more of a POC than an actual formal PR, to generate some discussion.  

Codewise, there is not much to this, however the larger discussion is had the use case for this feature.  The issue is that 99% of the (default) use cases don't need to read in multiple values from a Config object(and thus a path parameter makes sense), since its one field per value usually.  However, case classes are the very large exception to that rule AND also one of this libraries greater conveniences, so there is a bit of a weird relationship going on there.  They are a bit at odds with each other.

That being said, I still decided to go ahead with this POC, just to show what a potential fix could look like:

I added a new function to ValueReader 
```scala
def read(config : Config) : A 
```

In an effort to not break compatibility, I opted to give it a default implementation of..throwing 🥇 🤕 🤒 . (which I totally do not like, but there really is no good default for this).  


The `ArbitraryTypeReader` macro was updated to give an implementation to this new function, which allows it to take a `Config` object and directly pull values from it, without the need for the optional `path` parameter.

I updated some tests to make sure it all works, which so far seem to be a go.

So...outstanding issues:

- I don't like the default throwing behavior at all, it was plane food.  One other option would be to have a separate trait which houses this new function definition, and then have the `ArbitraryTypeReader`s macro generate an impl for that.  Then, the `as` function on the `FicusConfig` instance could match on the `ValueReader` type and throw if the `ValueReader` is not of that type.  Not a 100% better, but at least a bit more obvious and not a throwing mess.
- should there be an equivalent `getAs` function? If so, should the catching behavior catch the above mismatch, or is that something that should still be thrown? I lean towards having it throw if the `ValueReader` is not of the appropriate type, as this could mean a programming error, not a configuration error(potentially).  I feel like either side could be argued successfully.




