### PR TITLE
Bump scala

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 scala:
   - 2.10.6
   - 2.11.11
-  - 2.12.3
+  - 2.12.7
 jdk:
   - oraclejdk8
   - openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ startYear := Some(2013)
 /* scala versions and options */
 scalaVersion := "2.11.11"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.10.6", "2.12.3")
+crossScalaVersions := Seq(scalaVersion.value, "2.10.6", "2.12.7")
 
 // These options will be used for *all* versions.
 scalacOptions ++= Seq(


### PR DESCRIPTION
Release notes: https://github.com/scala/scala/releases/tag/v2.12.7

> Compiler performance has improved significantly again, and is mostly on par with 2.13. Concretely, you should see a 10% drop in compile times since 2.12.6, according to our compiler benchmarks.