### PR TITLE
Add InetSocketAddress readers

### DIFF
--- a/src/main/scala/net/ceedubs/ficus/Ficus.scala
+++ b/src/main/scala/net/ceedubs/ficus/Ficus.scala
@@ -8,6 +8,7 @@ trait FicusInstances extends AnyValReaders with StringReader with SymbolReader w
     with CollectionReaders with ConfigReader with DurationReaders
     with TryReader with ConfigValueReader with BigNumberReaders
     with ISOZonedDateTimeReader with PeriodReader with LocalDateReader with URIReaders with URLReader
+    with InetSocketAddressReaders
 
 object Ficus extends FicusInstances {
   implicit def toFicusConfig(config: Config): FicusConfig = SimpleFicusConfig(config)

--- a/src/main/scala/net/ceedubs/ficus/readers/InetSocketAddressReaders.scala
+++ b/src/main/scala/net/ceedubs/ficus/readers/InetSocketAddressReaders.scala
@@ -1,0 +1,44 @@
+package net.ceedubs.ficus.readers
+
+import java.net.InetSocketAddress
+
+import com.typesafe.config.{Config, ConfigException}
+
+trait InetSocketAddressReaders {
+  private def parseHostAndPort(unparsedHostAndPort: String): Option[InetSocketAddress] = {
+    val hostAndPort = """([a-zA-Z0-9\.\-]+)\s*:\s*(\d+)""".r
+    unparsedHostAndPort match {
+      case hostAndPort(host, port) ⇒
+        Some(new InetSocketAddress(host, port.toInt))
+      case _ ⇒
+        None
+    }
+  }
+
+  implicit val inetSocketAddressListReader: ValueReader[List[InetSocketAddress]] = new ValueReader[List[InetSocketAddress]] {
+    def read(config: Config, path: String): List[InetSocketAddress] =
+      try {
+        config.getString(path).split(", *").toList
+          .map(parseHostAndPort)
+          .partition(_.isEmpty) match {
+            case (errors, ok) if errors.isEmpty =>
+              ok.flatten
+            case _ =>
+              throw new IllegalArgumentException("Cannot parse string into hosts and ports")
+          }
+      } catch {
+        case e: Exception => throw new ConfigException.WrongType(config.origin(),path,"java.net.InetSocketAddress", "String", e)
+      }
+  }
+
+  implicit val inetSocketAddressReader: ValueReader[InetSocketAddress] = new ValueReader[InetSocketAddress] {
+    def read(config: Config, path: String): InetSocketAddress =
+      try {
+        parseHostAndPort(config.getString(path)).getOrElse(throw new IllegalArgumentException("Cannot parse string into host and port"))
+      } catch {
+        case e: Exception => throw new ConfigException.WrongType(config.origin(),path,"java.net.InetSocketAddress", "String", e)
+     }
+  }
+}
+
+object InetSocketAddressReaders extends InetSocketAddressReaders

--- a/src/test/scala/net/ceedubs/ficus/readers/InetSocketAddressReadersSpec.scala
+++ b/src/test/scala/net/ceedubs/ficus/readers/InetSocketAddressReadersSpec.scala
@@ -1,0 +1,76 @@
+package net.ceedubs.ficus.readers
+
+import java.net.InetSocketAddress
+
+import com.typesafe.config.ConfigException.WrongType
+import com.typesafe.config.ConfigFactory
+import net.ceedubs.ficus.Spec
+
+class InetSocketAddressReadersSpec extends Spec with InetSocketAddressReaders {
+  def is = s2"""
+  The InetSocketAddress value readers should
+    read a valid named InetSocketAddress $readValidNamedInetSocketAddress
+    read a valid raw InetSocketAddress $readValidRawInetSocketAddress
+    detect wrong type on a malformed InetSocketAddress $readMalformedInetSocketAddress
+    read a valid comma-separated list of InetSocketAddresses $readValidInetSocketAddresses
+    read a valid comma-separated list of InetSocketAddresses surrounded by whitespace $readValidInetSocketAddressesWithWhiteSpace
+    detect wrong type on malformed InetSocketAddresses $readMalformedInetSocketAddresses
+    be able to read a single InetSocketAddress as a list of InetSocketAddresses $readSingleInetSocketAddress
+  """
+
+  def readValidNamedInetSocketAddress = {
+    val inetSocketAddress = """localhost:65535"""
+    val cfg = ConfigFactory.parseString(s"myValue = ${"\"" + inetSocketAddress + "\""}")
+    inetSocketAddressReader.read(cfg, "myValue") must beEqualTo(new InetSocketAddress("localhost", 65535))
+  }
+
+  def readValidRawInetSocketAddress = {
+    val inetSocketAddress = """127.0.0.1:65535"""
+    val cfg = ConfigFactory.parseString(s"myValue = ${"\"" + inetSocketAddress + "\""}")
+    inetSocketAddressReader.read(cfg, "myValue") must beEqualTo(new InetSocketAddress("127.0.0.1", 65535))
+  }
+
+  def readMalformedInetSocketAddress = {
+    val malformedInetSocketAddress = """localhost123"""
+    val cfg = ConfigFactory.parseString(s"myValue = ${"\"" + malformedInetSocketAddress + "\""}")
+    inetSocketAddressReader.read(cfg, "myValue") must throwA[WrongType]
+  }
+
+  def readValidInetSocketAddresses = {
+    val inetSocketAddresses = """localhost:65535,localhost:80,localhost:443"""
+    val cfg = ConfigFactory.parseString(s"myValue = ${"\"" + inetSocketAddresses + "\""}")
+    inetSocketAddressListReader.read(cfg, "myValue") must beEqualTo(
+      List(
+      new InetSocketAddress("localhost", 65535),
+        new InetSocketAddress("localhost", 80),
+        new InetSocketAddress("localhost", 443)
+      )
+    )
+  }
+
+  def readValidInetSocketAddressesWithWhiteSpace = {
+    val inetSocketAddresses = """localhost: 65535, localhost: 80, localhost: 443"""
+    val cfg = ConfigFactory.parseString(s"myValue = ${"\"" + inetSocketAddresses + "\""}")
+    inetSocketAddressListReader.read(cfg, "myValue") must beEqualTo(
+      List(
+        new InetSocketAddress("localhost", 65535),
+        new InetSocketAddress("localhost", 80),
+        new InetSocketAddress("localhost", 443)
+      )
+    )
+  }
+
+  def readMalformedInetSocketAddresses = {
+    val malformedInetSocketAddresses = """localhost:65535 + localhost:80"""
+    val cfg = ConfigFactory.parseString(s"myValue = ${"\"" + malformedInetSocketAddresses + "\""}")
+    inetSocketAddressListReader.read(cfg, "myValue") must throwA[WrongType]
+  }
+
+  def readSingleInetSocketAddress = {
+    val inetSocketAddress = """localhost:65535"""
+    val cfg = ConfigFactory.parseString(s"myValue = ${"\"" + inetSocketAddress + "\""}")
+    inetSocketAddressListReader.read(cfg, "myValue") must beEqualTo(
+      List(new InetSocketAddress("localhost", 65535))
+    )
+  }
+}


### PR DESCRIPTION
Applying this PR will add a reader for turning a `host:port` pair into an `InetSocketAddress` and a reader for turning a comma-separated list of `host:port` pairs into a `List` of `InetSocketAddress`es.