### PR TITLE
Update scala, sbt and sbt-plugin versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,14 +7,14 @@ lazy val gcTask = gc := {
   System gc()
 }
 
-lazy val project = Project("project", file("."))
+lazy val root = project.in(file("."))
   .settings(
     /* basic project info */
     name := "ficus",
     description := "A Scala-friendly wrapper companion for Typesafe config",
     startYear := Some(2013),
     scalaVersion := "2.12.14",
-    crossScalaVersions := Seq("2.10.7", "2.11.12", scalaVersion.value, "2.13.4"),
+    crossScalaVersions := Seq("2.10.7", "2.11.12", scalaVersion.value, "2.13.6"),
     scalacOptions ++= Seq(
       "-feature",
       "-deprecation",
@@ -30,23 +30,23 @@ lazy val project = Project("project", file("."))
     javacOptions ++= Seq(
       "-Xlint:unchecked", "-Xlint:deprecation"
     ),
-    unmanagedSourceDirectories in Compile ++= {
-      (unmanagedSourceDirectories in Compile).value.map { dir =>
+    Compile / unmanagedSourceDirectories ++= {
+      (Compile / unmanagedSourceDirectories).value.map { dir =>
         CrossVersion.partialVersion(scalaVersion.value) match {
           case Some((2, 13)) => file(dir.getPath ++ "-2.13+")
           case _             => file(dir.getPath ++ "-2.13-")
         }
       }
     },
-    unmanagedSourceDirectories in Test ++= {
-      (unmanagedSourceDirectories in Test).value.map { dir =>
+    Test / unmanagedSourceDirectories ++= {
+      (Test / unmanagedSourceDirectories).value.map { dir =>
         CrossVersion.partialVersion(scalaVersion.value) match {
           case Some((2, 13)) => file(dir.getPath ++ "-2.13+")
           case _ =>  file(dir.getPath ++ "-2.13-")
         }
       }
     },
-    libraryDependencies ++= 
+    libraryDependencies ++=
       (if (scalaVersion.value.startsWith("2.10"))
          Seq(
            "org.specs2"     %% "specs2-core"       % "3.10.0" % Test,
@@ -54,7 +54,7 @@ lazy val project = Project("project", file("."))
        else
          Seq(
            "org.specs2"     %% "specs2-core"       % "4.8.3" % Test,
-           "org.specs2"     %% "specs2-scalacheck" % "4.8.3" % Test)) ++ 
+           "org.specs2"     %% "specs2-scalacheck" % "4.8.3" % Test)) ++
          Seq(
            "org.scalacheck" %% "scalacheck"        % "1.14.1" % Test,
            "com.chuusai"    %% "shapeless"         % "2.3.3"  % Test,
@@ -72,13 +72,13 @@ lazy val project = Project("project", file("."))
       Resolver.bintrayRepo("iheartradio","maven"),
       Resolver.jcenterRepo
     ),
-    parallelExecution in Test := true,
+    Test / parallelExecution := true,
     /* sbt behavior */
-    logLevel in compile := Level.Warn,
+    compile / logLevel := Level.Warn,
     traceLevel := 5,
     offline := false,
-    mappings in (Compile, packageBin) := {
-      val ms = mappings.in(Compile, packageBin).value
+    Compile / packageBin / mappings := {
+      val ms = (Compile / packageBin / mappings).value
       ms filter { case (_, toPath) =>
         toPath != "application.conf"
       }

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,5 +1,6 @@
-import com.typesafe.sbt.pgp.PgpKeys
-import sbt._, Keys._
+import sbt._
+import Keys._
+import com.jsuereth.sbtpgp.PgpKeys
 import sbtrelease.ReleasePlugin.autoImport._
 import sbtrelease.ReleaseStateTransformations._
 
@@ -25,7 +26,7 @@ object Publish {
 
   val publishingSettings = Seq(
 
-    organization in ThisBuild := "com.iheart",
+    ThisBuild / organization := "com.iheart",
     publishMavenStyle := true,
     licenses := Seq("MIT" -> url("http://www.opensource.org/licenses/mit-license.html")),
     homepage := Some(url("http://iheartradio.github.io/ficus")),
@@ -34,7 +35,7 @@ object Publish {
       "git@github.com:iheartradio/ficus.git",
       Some("git@github.com:iheartradio/ficus.git"))),
     pomIncludeRepository := { _ => false },
-    publishArtifact in Test := false,
+    Test / publishArtifact := false,
     publishTo := {
       val nexus = "https://oss.sonatype.org/"
       if (isSnapshot.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.5.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,13 @@
 resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.1")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.0")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.1-SNAPSHOT"
+ThisBuild / version := "1.5.1-SNAPSHOT"


### PR DESCRIPTION
This PR does the following things

1. Update SBT to its latest version (1.5.4). This version of SBT also deprecates the `in` syntax with `/` syntax (which has also been done)
2. Update SBT plugins to their latest versions as well as doing any required changes
3. Update Scala 2.12.4 to 2.12.6. This is important Scala3 support